### PR TITLE
libucl-0.9.4

### DIFF
--- a/libucl/README
+++ b/libucl/README
@@ -4,27 +4,27 @@ UCL is heavily infused by nginx configuration as the example of a convenient
 configuration system.
 
 Runtime requirements:
-  cygwin-3.6.6-1
-  libcurl4-8.18.0-1
+  cygwin-3.6.10-1
+  libcurl4-8.20.0-1
   liblua5.3-5.3.6-4
-  libssl3-3.0.18-1
-  libucl-devel-0.9.3-1bl1
-  libucl6-0.9.3-1bl1
-  pkg-config-2.5.1-1
+  libssl3-3.5.7-1
+  libucl-devel-0.9.4-1bl1
+  libucl5-0.9.4-1bl1
+  pkg-config-3.0.5-1
 
 Build requirements:
 (besides corresponding -devel packages)
-  autoconf-15-2
+  autoconf-15-3
   autoconf-archive-2024.10.16-1
   automake-20250528-1
-  binutils-2.45.1-1
-  cygport-0.37.6-1
-  gcc-core-13.4.0-1
-  gcc-g++-13.4.0-1
-  libcurl-devel-8.18.0-1
+  binutils-2.47-1
+  cygport-0.37.7-1
+  gcc-core-14.4.0-1
+  gcc-g++-14.4.0-1
+  libcurl-devel-8.20.0-1
   liblua-devel-5.3.6-4
-  libssl-devel-3.0.18-1
-  libtool-2.5.4-1
+  libssl-devel-3.5.7-1
+  libtool-2.6.2-1
   lua-5.3.6-4
   make-4.4.1-2
 
@@ -32,23 +32,23 @@ Canonical website:
   https://github.com/vstakhov/libucl
 
 Canonical download:
-  https://github.com/vstakhov/libucl/archive/refs/tags/0.9.3.tar.gz
+  https://github.com/vstakhov/libucl/archive/refs/tags/0.9.4.tar.gz
 
 -------------------------------------------
 
 Build instructions:
-  1. unpack libucl-0.9.3-X-src.tar.xz
+  1. unpack libucl-0.9.4-X-src.tar.xz
   2. if you use setup to install this src package,
      it will be unpacked under /usr/src automatically
         % cd /usr/src
-        % cygport ./libucl-0.9.3-X.cygport all
+        % cygport ./libucl-0.9.4-X.cygport all
 
 This will create:
-  /usr/src/libucl-0.9.3-X-src.tar.xz
-  /usr/src/libucl-0.9.3-X.tar.xz
-  /usr/src/libucl6-0.9.3-X.tar.xz
-  /usr/src/libucl-devel-0.9.3-X.tar.xz
-  /usr/src/lua-libucl-0.9.3-X.tar.xz
+  /usr/src/libucl-0.9.4-X-src.tar.xz
+  /usr/src/libucl-0.9.4-X.tar.xz
+  /usr/src/libucl5-0.9.4-X.tar.xz
+  /usr/src/libucl-devel-0.9.4-X.tar.xz
+  /usr/src/lua-libucl-0.9.4-X.tar.xz
 
 -------------------------------------------
 
@@ -63,8 +63,8 @@ Files included in the binary package:
   /usr/share/doc/libucl/ChangeLog.md
   /usr/share/doc/libucl/README.md
 
-(libucl6)
-  /usr/bin/cygucl-6.dll
+(libucl5)
+  /usr/bin/cygucl-5.dll
 
 (libucl-devel)
   /usr/include/lua_ucl.h
@@ -80,6 +80,9 @@ Files included in the binary package:
 ------------------
 
 Port Notes:
+
+----- version 0.9.4-1bl1 -----
+Version bump.
 
 ----- version 0.9.3-1bl1 -----
 Version bump.

--- a/libucl/libucl-0.9.4-1bl1.cygport
+++ b/libucl/libucl-0.9.4-1bl1.cygport
@@ -11,9 +11,11 @@ LICENSE_SPDX="SPDX-License-Identifier: BSD-2-Clause"
 LICENSE_URI="COPYING"
 
 BUILD_REQUIRES="
+	autoconf-archive
 	libcurl-devel
 	liblua-devel
 	libssl-devel
+	lua
 "
 
 CYGCONF_ARGS="
@@ -25,7 +27,7 @@ CYGCONF_ARGS="
 
 PKG_NAMES="
 	libucl
-	libucl6
+	libucl5
 	libucl-devel
 	lua-libucl
 "
@@ -33,8 +35,8 @@ libucl_CONTENTS="
 	usr/bin/*.exe
 	usr/share/doc
 "
-libucl6_CONTENTS="
-	usr/bin/cyg*-6.dll
+libucl5_CONTENTS="
+	usr/bin/cyg*-5.dll
 "
 libucl_devel_CONTENTS="
 	usr/include
@@ -46,6 +48,6 @@ lua_libucl_CONTENTS="
 	usr/lib/lua
 "
 libucl_SUMMARY="${SUMMARY} (licensing & readmes)"
-libucl6_SUMMARY="${SUMMARY} (runtime)"
+libucl5_SUMMARY="${SUMMARY} (runtime)"
 libucl_devel_SUMMARY="${SUMMARY} (development)"
 lua_libucl_SUMMARY="${SUMMARY} (lua bindings)"

--- a/libucl/libucl-0.9.4-1bl1.src.patch
+++ b/libucl/libucl-0.9.4-1bl1.src.patch
@@ -1,5 +1,16 @@
---- origsrc/libucl-0.9.3/lua/Makefile.am	2025-12-09 21:10:07.000000000 +0900
-+++ src/libucl-0.9.3/lua/Makefile.am	2026-01-22 13:41:36.063313500 +0900
+--- origsrc/libucl-0.9.4/configure.ac	2026-02-17 10:43:22.000000000 +0000
++++ src/libucl-0.9.4/configure.ac	2026-08-10 23:13:21.300967900 +0000
+@@ -107,7 +107,7 @@ AS_IF([test "x$enable_regex" = "xyes"],
+ AC_SUBST(LIBREGEX_LIB)
+ 
+ AS_IF([test "x$enable_lua" = "xyes"], [
+-	AX_PROG_LUA([5.1], [], [
++	AX_PROG_LUA([5.3], [], [
+ 		AX_LUA_HEADERS([
+ 			AX_LUA_LIBS([
+ 				AC_DEFINE(HAVE_LUA, 1, [Define to 1 for lua support.])
+--- origsrc/libucl-0.9.4/lua/Makefile.am	2026-02-17 10:43:22.000000000 +0000
++++ src/libucl-0.9.4/lua/Makefile.am	2026-08-10 23:13:21.301739900 +0000
 @@ -6,8 +6,8 @@ luaexec_LTLIBRARIES=	ucl.la
  ucl_la_SOURCES=	lua_ucl.c
  ucl_la_CFLAGS=	$(ucl_common_cflags) \
@@ -11,8 +22,8 @@
  					@LIBFETCH_LIBS@ \
  					@LIBCRYPTO_LIB@ \
  					@LIBREGEX_LIB@ \
---- origsrc/libucl-0.9.3/src/Makefile.am	2025-12-09 21:10:07.000000000 +0900
-+++ src/libucl-0.9.3/src/Makefile.am	2026-01-22 12:17:03.852249800 +0900
+--- origsrc/libucl-0.9.4/src/Makefile.am	2026-02-17 10:43:22.000000000 +0000
++++ src/libucl-0.9.4/src/Makefile.am	2026-08-10 23:13:21.302981100 +0000
 @@ -15,7 +15,7 @@ libucl_la_SOURCES=	ucl_emitter.c \
  					ucl_sexp.c
  libucl_la_CFLAGS=	$(libucl_common_cflags) \


### PR DESCRIPTION
Version `0.9.4`, built and validated by [dorgann](https://github.com/fd00/dorgann).

Run: https://github.com/fd00/dorgann/actions/runs/31441229451

<!-- dorgann-meta: {"artifact_id":"9083039432"} -->

To publish this build as a devel package on gh-pages:
```
gh workflow run publish-devel.yml -f artifact_id=9083039432 --repo fd00/dorgann
```