### PR TITLE
libunibreak-7.0

### DIFF
--- a/libunibreak/README
+++ b/libunibreak/README
@@ -3,41 +3,41 @@ libunibreak
 Library to implement Unicode algorithms for line and word breaking
 
 Runtime requirements:
-  cygwin-3.5.4-1
-  libunibreak-devel-6.1-1bl1
-  libunibreak6-6.1-1bl1
-  pkg-config-2.3.0-1
+  cygwin-3.6.10-1
+  libunibreak-devel-7.0-1bl1
+  libunibreak7-7.0-1bl1
+  pkg-config-3.0.5-1
 
 Build requirements:
 (besides corresponding -devel packages)
-  autoconf-15-2
-  automake-20240607-1
-  binutils-2.43.1-1
-  cygport-0.36.9-1
-  gcc-core-12.4.0-3
-  libtool-2.4.7-1
+  autoconf-15-3
+  automake-20250528-1
+  binutils-2.47-1
+  cygport-0.37.7-1
+  gcc-core-14.4.0-1
+  libtool-2.6.2-1
   make-4.4.1-2
 
 Canonical website:
   https://github.com/adah1972/libunibreak
 
 Canonical download:
-  https://github.com/adah1972/libunibreak/archive/refs/tags/libunibreak_6_1.tar.gz
+  https://github.com/adah1972/libunibreak/archive/refs/tags/libunibreak_7_0.tar.gz
 
 -------------------------------------------
 
 Build instructions:
-  1. unpack libunibreak-6.1-X-src.tar.xz
+  1. unpack libunibreak-7.0-X-src.tar.xz
   2. if you use setup to install this src package,
      it will be unpacked under /usr/src automatically
         % cd /usr/src
-        % cygport ./libunibreak-6.1-X.cygport all
+        % cygport ./libunibreak-7.0-X.cygport all
 
 This will create:
-  /usr/src/libunibreak-6.1-X-src.tar.xz
-  /usr/src/libunibreak-6.1-X.tar.xz
-  /usr/src/libunibreak6-6.1-X.tar.xz
-  /usr/src/libunibreak-devel-6.1-X.tar.xz
+  /usr/src/libunibreak-7.0-X-src.tar.xz
+  /usr/src/libunibreak-7.0-X.tar.xz
+  /usr/src/libunibreak7-7.0-X.tar.xz
+  /usr/src/libunibreak-devel-7.0-X.tar.xz
 
 -------------------------------------------
 
@@ -50,8 +50,8 @@ Files included in the binary package:
   /usr/share/doc/libunibreak/NEWS
   /usr/share/doc/libunibreak/README.md
 
-(libunibreak6)
-  /usr/bin/cygunibreak-6.dll
+(libunibreak7)
+  /usr/bin/cygunibreak-7.dll
 
 (libunibreak-devel)
   /usr/include/libunibreak/eastasianwidthdef.h
@@ -67,6 +67,9 @@ Files included in the binary package:
 ------------------
 
 Port Notes:
+
+----- version 7.0-1bl1 -----
+Version bump.
 
 ----- version 6.1-1bl1 -----
 Initial release by fd0 <https://github.com/fd00/>

--- a/libunibreak/libunibreak-7.0-1bl1.cygport
+++ b/libunibreak/libunibreak-7.0-1bl1.cygport
@@ -16,19 +16,19 @@ CYGCONF_ARGS="
 
 PKG_NAMES="
 	libunibreak
-	libunibreak6
+	libunibreak7
 	libunibreak-devel
 "
 libunibreak_CONTENTS="
 	usr/share
 "
-libunibreak6_CONTENTS="
-	usr/bin/cyg*-6.dll
+libunibreak7_CONTENTS="
+	usr/bin/cyg*-7.dll
 "
 libunibreak_devel_CONTENTS="
 	usr/include
 	usr/lib
 "
 libunibreak_SUMMARY="${SUMMARY} (licensing & readmes)"
-libunibreak6_SUMMARY="${SUMMARY} (runtime)"
+libunibreak7_SUMMARY="${SUMMARY} (runtime)"
 libunibreak_devel_SUMMARY="${SUMMARY} (development)"


### PR DESCRIPTION
Version `7.0`, built and validated by [dorgann](https://github.com/fd00/dorgann).

Run: https://github.com/fd00/dorgann/actions/runs/31449758928

<!-- dorgann-meta: {"artifact_id":"9085970405"} -->

To publish this build to gh-pages:
```
gh workflow run publish.yml -f artifact_id=9085970405 --repo fd00/dorgann
```