### PR TITLE
libvalkey-0.5.0

### DIFF
--- a/libvalkey/README
+++ b/libvalkey/README
@@ -5,47 +5,47 @@ any server that uses the RESP protocol (version 2 or 3). This project
 supports both standalone and cluster modes.
 
 Runtime requirements:
-  cygwin-3.6.7-1
-  libssl3-3.0.19-1
-  libvalkey-devel-0.4.0-1bl1
-  libvalkey0-0.4.0-1bl1
-  libvalkey_tls-devel-0.4.0-1bl1
-  libvalkey_tls0-0.4.0-1bl1
-  pkg-config-2.5.1-1
+  cygwin-3.6.10-1
+  libssl3-3.5.7-1
+  libvalkey-devel-0.5.0-1bl1
+  libvalkey0-0.5.0-1bl1
+  libvalkey_tls-devel-0.5.0-1bl1
+  libvalkey_tls0-0.5.0-1bl1
+  pkg-config-3.0.5-1
 
 Build requirements:
 (besides corresponding -devel packages)
-  binutils-2.46-1
+  binutils-2.47-1
   cmake-4.2.1-1
   cygport-0.37.7-1
-  gcc-core-13.4.0-1
-  gcc-g++-13.4.0-1
-  libssl-devel-3.0.19-1
+  gcc-core-14.4.0-1
+  gcc-g++-14.4.0-1
+  libssl-devel-3.5.7-1
   ninja-1.13.2-1
-  perl-JSON-4.11-1
+  perl-JSON-MaybeXS-1.004008-2
 
 Canonical website:
   https://github.com/valkey-io/libvalkey
 
 Canonical download:
-  https://github.com/valkey-io/libvalkey/archive/refs/tags/0.4.0.tar.gz
+  https://github.com/valkey-io/libvalkey/archive/refs/tags/0.5.0.tar.gz
 
 -------------------------------------------
 
 Build instructions:
-  1. unpack libvalkey-0.4.0-X-src.tar.xz
+  1. unpack libvalkey-0.5.0-X-src.tar.xz
   2. if you use setup to install this src package,
      it will be unpacked under /usr/src automatically
         % cd /usr/src
-        % cygport ./libvalkey-0.4.0-X.cygport all
+        % cygport ./libvalkey-0.5.0-X.cygport all
 
 This will create:
-  /usr/src/libvalkey-0.4.0-X-src.tar.xz
-  /usr/src/libvalkey-0.4.0-X.tar.xz
-  /usr/src/libvalkey0-0.4.0-X.tar.xz
-  /usr/src/libvalkey-devel-0.4.0-X.tar.xz
-  /usr/src/libvalkey_tls0-0.4.0-X.tar.xz
-  /usr/src/libvalkey_tls-devel-0.4.0-X.tar.xz
+  /usr/src/libvalkey-0.5.0-X-src.tar.xz
+  /usr/src/libvalkey-0.5.0-X.tar.xz
+  /usr/src/libvalkey0-0.5.0-X.tar.xz
+  /usr/src/libvalkey-devel-0.5.0-X.tar.xz
+  /usr/src/libvalkey_tls0-0.5.0-X.tar.xz
+  /usr/src/libvalkey_tls-devel-0.5.0-X.tar.xz
 
 -------------------------------------------
 
@@ -81,7 +81,7 @@ Files included in the binary package:
   /usr/include/valkey/visibility.h
   /usr/lib/cmake/valkey/valkey-config-version.cmake
   /usr/lib/cmake/valkey/valkey-config.cmake
-  /usr/lib/cmake/valkey/valkey-targets-release.cmake
+  /usr/lib/cmake/valkey/valkey-targets-relwithdebinfo.cmake
   /usr/lib/cmake/valkey/valkey-targets.cmake
   /usr/lib/libvalkey.dll.a
   /usr/lib/pkgconfig/valkey.pc
@@ -92,7 +92,7 @@ Files included in the binary package:
 (libvalkey_tls-devel)
   /usr/include/valkey/tls.h
   /usr/lib/cmake/valkey_tls/valkey_tls-config.cmake
-  /usr/lib/cmake/valkey_tls/valkey_tls-targets-release.cmake
+  /usr/lib/cmake/valkey_tls/valkey_tls-targets-relwithdebinfo.cmake
   /usr/lib/cmake/valkey_tls/valkey_tls-targets.cmake
   /usr/lib/libvalkey_tls.dll.a
   /usr/lib/pkgconfig/valkey_tls.pc
@@ -100,6 +100,9 @@ Files included in the binary package:
 ------------------
 
 Port Notes:
+
+----- version 0.5.0-1bl1 -----
+Version bump.
 
 ----- version 0.4.0-1bl1 -----
 Version bump.

--- a/libvalkey/libvalkey-0.5.0-1bl1.cygport
+++ b/libvalkey/libvalkey-0.5.0-1bl1.cygport
@@ -13,7 +13,7 @@ LICENSE_URI="COPYING"
 
 BUILD_REQUIRES="
 	libssl-devel
-	perl-JSON
+	perl-JSON-MaybeXS
 "
 
 inherit cmake

--- a/libvalkey/libvalkey-0.5.0-1bl1.src.patch
+++ b/libvalkey/libvalkey-0.5.0-1bl1.src.patch
@@ -1,5 +1,5 @@
---- origsrc/libvalkey-0.4.0/CMakeLists.txt	2026-02-23 20:51:21.000000000 +0900
-+++ src/libvalkey-0.4.0/CMakeLists.txt	2026-03-24 11:29:41.445271800 +0900
+--- origsrc/libvalkey-0.5.0/CMakeLists.txt	2026-05-13 11:10:49.000000000 +0000
++++ src/libvalkey-0.5.0/CMakeLists.txt	2026-08-11 02:06:35.733841300 +0000
 @@ -32,7 +32,7 @@ SET(CMAKE_DEBUG_POSTFIX d)
  
  # Set target-common flags


### PR DESCRIPTION
Version `0.5.0`, built and validated by [dorgann](https://github.com/fd00/dorgann).

Run: https://github.com/fd00/dorgann/actions/runs/31451177357

<!-- dorgann-meta: {"artifact_id":"9086441373"} -->

To publish this build to gh-pages:
```
gh workflow run publish.yml -f artifact_id=9086441373 --repo fd00/dorgann
```