### PR TITLE
mlite-0.5.5

### DIFF
--- a/mlite/README
+++ b/mlite/README
@@ -4,46 +4,46 @@ Useful classes originating from MeeGo Touch
 
 Runtime requirements:
   bash-5.2.21-1
-  cygwin-3.5.7-1
+  cygwin-3.6.10-1
   libQt5Core-devel-5.9.4-2
   libQt5Core5-5.9.4-2
-  libgcc1-12.4.0-3
-  libglib2.0_0-2.84.0-1
-  libmlite5-devel-0.5.3-1bl1
-  libmlite5_0-0.5.3-1bl1
-  libstdc++6-12.4.0-3
-  pkg-config-2.3.0-1
+  libgcc1-14.4.0-1
+  libglib2.0_0-2.88.3-1
+  libmlite5-devel-0.5.5-1bl1
+  libmlite5_0-0.5.5-1bl1
+  libstdc++6-14.4.0-1
+  pkg-config-3.0.5-1
 
 Build requirements:
 (besides corresponding -devel packages)
-  binutils-2.44-1
-  cygport-0.36.9-1
-  gcc-core-12.4.0-3
-  gcc-g++-12.4.0-3
+  binutils-2.47-1
+  cygport-0.37.7-1
+  gcc-core-14.4.0-1
+  gcc-g++-14.4.0-1
   libQt5Core-devel-5.9.4-2
-  libglib2.0-devel-2.84.0-1
+  libglib2.0-devel-2.88.3-1
   make-4.4.1-2
 
 Canonical website:
   https://github.com/sailfishos/mlite
 
 Canonical download:
-  https://github.com/sailfishos/mlite/archive/refs/tags/0.5.3.tar.gz
+  https://github.com/sailfishos/mlite/archive/refs/tags/0.5.5.tar.gz
 
 -------------------------------------------
 
 Build instructions:
-  1. unpack mlite-0.5.3-X-src.tar.xz
+  1. unpack mlite-0.5.5-X-src.tar.xz
   2. if you use setup to install this src package,
      it will be unpacked under /usr/src automatically
         % cd /usr/src
-        % cygport ./mlite-0.5.3-X.cygport all
+        % cygport ./mlite-0.5.5-X.cygport all
 
 This will create:
-  /usr/src/mlite-0.5.3-X-src.tar.xz
-  /usr/src/mlite-0.5.3-X.tar.xz
-  /usr/src/libmlite5_0-0.5.3-X.tar.xz
-  /usr/src/libmlite5-devel-0.5.3-X.tar.xz
+  /usr/src/mlite-0.5.5-X-src.tar.xz
+  /usr/src/mlite-0.5.5-X.tar.xz
+  /usr/src/libmlite5_0-0.5.5-X.tar.xz
+  /usr/src/libmlite5-devel-0.5.5-X.tar.xz
 
 -------------------------------------------
 
@@ -85,6 +85,9 @@ Files included in the binary package:
 ------------------
 
 Port Notes:
+
+----- version 0.5.5-1bl1 -----
+Version bump.
 
 ----- version 0.5.3-1bl1 -----
 Version bump.

--- a/mlite/mlite-0.5.5-1bl1.cygport
+++ b/mlite/mlite-0.5.5-1bl1.cygport
@@ -9,7 +9,10 @@ LICENSE="LGPL-2.1-or-later"
 LICENSE_SPDX="SPDX-License-Identifier: LGPL-2.1-or-later"
 LICENSE_URI="LICENSE.LGPL"
 
-BUILD_REQUIRES="libglib2.0-devel"
+BUILD_REQUIRES="
+	libQt5Core-devel
+	libglib2.0-devel
+"
 
 inherit qt5-qmake
 

--- a/mlite/mlite-0.5.5-1bl1.src.patch
+++ b/mlite/mlite-0.5.5-1bl1.src.patch
@@ -1,5 +1,5 @@
---- origsrc/mlite-0.5.3/tests/tests_common.pri	2025-02-05 20:06:41.000000000 +0900
-+++ src/mlite-0.5.3/tests/tests_common.pri	2025-03-18 08:20:46.370289500 +0900
+--- origsrc/mlite-0.5.5/tests/tests_common.pri	2026-01-14 12:01:11.000000000 +0000
++++ src/mlite-0.5.5/tests/tests_common.pri	2026-08-11 03:47:45.251094500 +0000
 @@ -3,7 +3,7 @@ TESTS_COMMON_PRI_INCLUDED = 1
  
  include(../common.pri)


### PR DESCRIPTION
Version `0.5.5`, built and validated by [dorgann](https://github.com/fd00/dorgann).

Run: https://github.com/fd00/dorgann/actions/runs/31456265840

<!-- dorgann-meta: {"artifact_id":"9088258978"} -->

To publish this build to gh-pages:
```
gh workflow run publish.yml -f artifact_id=9088258978 --repo fd00/dorgann
```