### PR TITLE
eatmemory-1.1.0

### DIFF
--- a/eatmemory/README
+++ b/eatmemory/README
@@ -3,33 +3,33 @@ eatmemory
 Simple C program to allocate memory from the command line
 
 Runtime requirements:
-  cygwin-3.5.0-1
+  cygwin-3.6.10-1
 
 Build requirements:
 (besides corresponding -devel packages)
-  binutils-2.42-1
-  cygport-0.36.8-1
-  gcc-core-11.4.0-1
+  binutils-2.47-1
+  cygport-0.37.7-1
+  gcc-core-14.4.0-1
   make-4.4.1-2
 
 Canonical website:
   https://github.com/julman99/eatmemory
 
 Canonical download:
-  https://github.com/julman99/eatmemory/archive/v0.1.10.tar.gz
+  https://github.com/julman99/eatmemory/archive/refs/tags/v1.1.0.tar.gz
 
 -------------------------------------------
 
 Build instructions:
-  1. unpack eatmemory-0.1.10-X-src.tar.xz
+  1. unpack eatmemory-1.1.0-X-src.tar.xz
   2. if you use setup to install this src package,
      it will be unpacked under /usr/src automatically
         % cd /usr/src
-        % cygport ./eatmemory-0.1.10-X.cygport all
+        % cygport ./eatmemory-1.1.0-X.cygport all
 
 This will create:
-  /usr/src/eatmemory-0.1.10-X-src.tar.xz
-  /usr/src/eatmemory-0.1.10-X.tar.xz
+  /usr/src/eatmemory-1.1.0-X-src.tar.xz
+  /usr/src/eatmemory-1.1.0-X.tar.xz
 
 -------------------------------------------
 
@@ -44,6 +44,9 @@ Files included in the binary package:
 ------------------
 
 Port Notes:
+
+----- version 1.1.0-1bl1 -----
+Version bump.
 
 ----- version 0.1.10-1bl1 -----
 Version bump.

--- a/eatmemory/eatmemory-1.1.0-1bl1.cygport
+++ b/eatmemory/eatmemory-1.1.0-1bl1.cygport
@@ -1,5 +1,5 @@
 HOMEPAGE="https://github.com/julman99/${PN}"
-SRC_URI="https://github.com/julman99/${PN}/archive/v${PV}.tar.gz"
+SRC_URI="https://github.com/julman99/${PN}/archive/refs/tags/v${PV}.tar.gz"
 
 CATEGORY="Devel"
 SUMMARY="Simple C program to allocate memory from the command line"
@@ -13,17 +13,17 @@ src_compile()
 {
 	cd ${B}
 	lndirs
-	cygmake CFLAGS="${CFLAGS}" SRC="${PN}.c args/args.c"
+	cygmake VERSION="${PV}"
 }
 
 src_test()
 {
 	cd ${B}
-	./${PN}.exe -t 0 10M | grep "Eating 10485760 bytes in chunks of 1024"
+	verbose ./output/${PN}.exe --help
 }
 
 src_install()
 {
 	cd ${B}
-	dobin ${PN}.exe
+	dobin ./output/${PN}.exe
 }

--- a/eatmemory/eatmemory-1.1.0-1bl1.src.patch
+++ b/eatmemory/eatmemory-1.1.0-1bl1.src.patch
@@ -1,0 +1,27 @@
+--- origsrc/eatmemory-1.1.0/Makefile	2026-05-15 01:35:08.000000000 +0000
++++ src/eatmemory-1.1.0/Makefile	2026-08-11 07:42:44.873709200 +0000
+@@ -18,7 +18,8 @@ VERSION ?= $(shell (git describe --tags
+ # because $(CFLAGS) appears on the link command line below.
+ EXTRA_CFLAGS ?=
+ 
+-CFLAGS := -Wall -Wextra -std=c99 -O2 -g $(EXTRA_CFLAGS) -DVERSION='"$(VERSION)"'
++CFLAGS ?=
++CFLAGS += $(EXTRA_CFLAGS) -DVERSION='"$(VERSION)"'
+ LDFLAGS :=
+ 
+ # Prefer compiler target macros so cross-compilation selects the target
+@@ -69,12 +70,12 @@ ifndef SYS_SRC
+         SYS_BACKEND := Windows
+     else
+         SYS_SRC := $(SRC_DIR)/eatmemory.unknown.c
+-        SYS_BACKEND := Unkown OS
++        SYS_BACKEND := Unknown OS
+     endif
+ endif
+ SYS_BACKEND ?= $(patsubst eatmemory.%.c,%,$(notdir $(SYS_SRC)))
+ ifeq ($(SYS_BACKEND),unknown)
+-    SYS_BACKEND := Unkown OS
++    SYS_BACKEND := Unknown OS
+ endif
+ CFLAGS += -DSYSMEM_BACKEND='"$(SYS_BACKEND)"'
+ 


### PR DESCRIPTION
Version `1.1.0`, built and validated by [dorgann](https://github.com/fd00/dorgann).

Run: https://github.com/fd00/dorgann/actions/runs/31469862525

<!-- dorgann-meta: {"artifact_id":"9093005786"} -->

To publish this build to gh-pages:
```
gh workflow run publish.yml -f artifact_id=9093005786 --repo fd00/dorgann
```