### PR TITLE
ggml-0.19.0

### DIFF
--- a/ggml/README
+++ b/ggml/README
@@ -5,15 +5,15 @@ Tensor library for machine learning
 Runtime requirements:
   cygwin-3.6.10-1
   libgcc1-14.4.0-1
-  libggml-devel-0.17.0-1bl1
-  libggml0-0.17.0-1bl1
+  libggml-devel-0.19.0-1bl1
+  libggml0-0.19.0-1bl1
   libgomp1-14.4.0-1
   libstdc++6-14.4.0-1
-  pkg-config-3.0.4-1
+  pkg-config-3.0.5-1
 
 Build requirements:
 (besides corresponding -devel packages)
-  binutils-2.46.1-1
+  binutils-2.47-1
   cmake-4.2.1-1
   cygport-0.37.7-1
   gcc-core-14.4.0-1
@@ -24,22 +24,22 @@ Canonical website:
   https://github.com/ggml-org/ggml
 
 Canonical download:
-  https://github.com/ggml-org/ggml/archive/refs/tags/v0.17.0.tar.gz
+  https://github.com/ggml-org/ggml/archive/refs/tags/v0.19.0.tar.gz
 
 -------------------------------------------
 
 Build instructions:
-  1. unpack ggml-0.17.0-X-src.tar.xz
+  1. unpack ggml-0.19.0-X-src.tar.xz
   2. if you use setup to install this src package,
      it will be unpacked under /usr/src automatically
         % cd /usr/src
-        % cygport ./ggml-0.17.0-X.cygport all
+        % cygport ./ggml-0.19.0-X.cygport all
 
 This will create:
-  /usr/src/ggml-0.17.0-X-src.tar.xz
-  /usr/src/ggml-0.17.0-X.tar.xz
-  /usr/src/libggml0-0.17.0-X.tar.xz
-  /usr/src/libggml-devel-0.17.0-X.tar.xz
+  /usr/src/ggml-0.19.0-X-src.tar.xz
+  /usr/src/ggml-0.19.0-X.tar.xz
+  /usr/src/libggml0-0.19.0-X.tar.xz
+  /usr/src/libggml-devel-0.19.0-X.tar.xz
 
 -------------------------------------------
 
@@ -86,6 +86,9 @@ Files included in the binary package:
 ------------------
 
 Port Notes:
+
+----- version 0.19.0-1bl1 -----
+Version bump.
 
 ----- version 0.17.0-1bl1 -----
 Version bump.

--- a/ggml/ggml-0.19.0-1bl1.cygport
+++ b/ggml/ggml-0.19.0-1bl1.cygport
@@ -1,11 +1,10 @@
 HOMEPAGE="https://github.com/ggml-org/${PN}"
 SRC_URI="https://github.com/ggml-org/${PN}/archive/refs/tags/v${PV}.tar.gz"
 PATCH_URI="
-	https://sources.debian.org/data/main/${PN:0:1}/${PN}/${PV}-1/debian/patches/cmake-Add-option-to-install-tests.patch
-	https://sources.debian.org/data/main/${PN:0:1}/${PN}/${PV}-1/debian/patches/Downgrade-ROCm-dependency-to-5.5.patch
-	https://sources.debian.org/data/main/${PN:0:1}/${PN}/${PV}-1/debian/patches/Use-only-CPU-backend-in-build-time-tests.patch
-	https://sources.debian.org/data/main/${PN:0:1}/${PN}/${PV}-1/debian/patches/Take-over-some-tests-from-llama.cpp.patch
-	https://sources.debian.org/data/main/${PN:0:1}/${PN}/${PV}-1/debian/patches/tests-initialize-all-tensors-in-test_dsv4_hc.patch
+	https://sources.debian.org/data/main/${PN:0:1}/${PN}/0.18.1-1/debian/patches/cmake-Add-option-to-install-tests.patch
+	https://sources.debian.org/data/main/${PN:0:1}/${PN}/0.18.1-1/debian/patches/Downgrade-ROCm-dependency-to-5.5.patch
+	https://sources.debian.org/data/main/${PN:0:1}/${PN}/0.18.1-1/debian/patches/Use-only-CPU-backend-in-build-time-tests.patch
+	https://sources.debian.org/data/main/${PN:0:1}/${PN}/0.18.1-1/debian/patches/Take-over-some-tests-from-llama.cpp.patch
 "
 
 CATEGORY="Libs"
@@ -17,6 +16,10 @@ LICENSE_SPDX="SPDX-License-Identifier: MIT"
 LICENSE_URI="LICENSE"
 
 inherit cmake
+
+CYGCMAKE_ARGS="
+	-DGGML_CCACHE:BOOL=OFF
+"
 
 DOCS="
 	docs/*

--- a/ggml/ggml-0.19.0-1bl1.src.patch
+++ b/ggml/ggml-0.19.0-1bl1.src.patch
@@ -1,5 +1,5 @@
---- origsrc/ggml-0.17.0/CMakeLists.txt	2026-07-27 04:59:07.861155600 +0900
-+++ src/ggml-0.17.0/CMakeLists.txt	2026-07-27 05:03:10.513531400 +0900
+--- origsrc/ggml-0.19.0/CMakeLists.txt	2026-08-11 08:57:21.760654300 +0000
++++ src/ggml-0.19.0/CMakeLists.txt	2026-08-11 08:57:24.776193800 +0000
 @@ -11,7 +11,7 @@ set(GGML_VERSION_BASE "${GGML_VERSION_MA
  list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/")
  


### PR DESCRIPTION
Version `0.19.0`, built and validated by [dorgann](https://github.com/fd00/dorgann).

Run: https://github.com/fd00/dorgann/actions/runs/31475266342

<!-- dorgann-meta: {"artifact_id":"9095522505"} -->

To publish this build to gh-pages:
```
gh workflow run publish.yml -f artifact_id=9095522505 --repo fd00/dorgann
```