### PR TITLE
ecm-7.0.7

### DIFF
--- a/ecm/README
+++ b/ecm/README
@@ -1,48 +1,48 @@
 ecm
 ------------------------------------------
-gmp-ecm is a free implementation of the Elliptic Curve Method (ECM) for integer
-factorization.
+gmp-ecm is a free implementation of the Elliptic Curve Method (ECM) for
+integer factorization.
 
 Runtime requirements:
-  cygwin-3.6.0-1
-  libecm-devel-7.0.6-1bl1
-  libecm1-7.0.6-1bl1
+  cygwin-3.6.10-1
+  libecm-devel-7.0.7-1bl1
+  libecm1-7.0.7-1bl1
   libgmp10-6.3.0-1
-  libgomp1-12.4.0-3
-  pkg-config-2.4.3-1
+  libgomp1-14.4.0-1
+  pkg-config-3.0.5-1
 
 Build requirements:
 (besides corresponding -devel packages)
-  autoconf-15-2
-  automake-20240607-1
-  binutils-2.44-1
-  cygport-0.36.9-1
-  gcc-core-12.4.0-3
+  autoconf-15-3
+  automake-20250528-1
+  binutils-2.47-1
+  cygport-0.37.7-1
+  gcc-core-14.4.0-1
   libgmp-devel-6.3.0-1
-  libtool-2.5.4-1
-  libxslt-1.1.29-1
+  libtool-2.6.2-1
+  libxslt-1.1.43-1
   make-4.4.1-2
 
 Canonical website:
   https://gitlab.inria.fr/zimmerma/ecm/
 
 Canonical download:
-  https://gitlab.inria.fr/zimmerma/ecm/-/archive/git-7.0.6/ecm-git-7.0.6.tar.bz2
+  https://gitlab.inria.fr/zimmerma/ecm/-/archive/git-7.0.7/ecm-git-7.0.7.tar.bz2
 
 -------------------------------------------
 
 Build instructions:
-  1. unpack ecm-7.0.6-X-src.tar.xz
+  1. unpack ecm-7.0.7-X-src.tar.xz
   2. if you use setup to install this src package,
      it will be unpacked under /usr/src automatically
         % cd /usr/src
-        % cygport ./ecm-7.0.6-X.cygport all
+        % cygport ./ecm-7.0.7-X.cygport all
 
 This will create:
-  /usr/src/ecm-7.0.6-X-src.tar.xz
-  /usr/src/ecm-7.0.6-X.tar.xz
-  /usr/src/libecm1-7.0.6-X.tar.xz
-  /usr/src/libecm-devel-7.0.6-X.tar.xz
+  /usr/src/ecm-7.0.7-X-src.tar.xz
+  /usr/src/ecm-7.0.7-X.tar.xz
+  /usr/src/libecm1-7.0.7-X.tar.xz
+  /usr/src/libecm-devel-7.0.7-X.tar.xz
 
 -------------------------------------------
 
@@ -71,6 +71,9 @@ Files included in the binary package:
 ------------------
 
 Port Notes:
+
+----- version 7.0.7-1bl1 -----
+Version bump.
 
 ----- version 7.0.6-1bl1 -----
 Version bump.

--- a/ecm/ecm-7.0.7-1bl1.cygport
+++ b/ecm/ecm-7.0.7-1bl1.cygport
@@ -2,8 +2,8 @@ HOMEPAGE="https://gitlab.inria.fr/zimmerma/${PN}/"
 SRC_URI="https://gitlab.inria.fr/zimmerma/${PN}/-/archive/git-${PV}/${PN}-git-${PV}.tar.bz2"
 SRC_DIR="${PN}-git-${PV}"
 PATCH_URI="
-	https://sources.debian.org/data/main/g/gmp-ecm/7.0.6%2Bds-1/debian/patches/upstream-national_encoding.patch
-	https://sources.debian.org/data/main/g/gmp-ecm/7.0.6%2Bds-1/debian/patches/debianization-examples.patch
+	https://sources.debian.org/data/main/g/gmp-${PN}/7.0.6%2Bds-2/debian/patches/upstream-national_encoding.patch
+	https://sources.debian.org/data/main/g/gmp-${PN}/7.0.6%2Bds-2/debian/patches/debianization-examples.patch
 "
 
 CATEGORY="Libs"
@@ -15,7 +15,10 @@ LICENSE="GPL-3.0-only"
 LICENSE_SPDX="SPDX-License-Identifier: GPL-3.0-only"
 LICENSE_URI="COPYING"
 
-BUILD_REQUIRES="libgmp-devel libxslt"
+BUILD_REQUIRES="
+	libgmp-devel
+	libxslt
+"
 
 CYGCONF_ARGS="
 	--enable-openmp

--- a/ecm/ecm-7.0.7-1bl1.src.patch
+++ b/ecm/ecm-7.0.7-1bl1.src.patch
@@ -1,15 +1,15 @@
---- origsrc/ecm-git-7.0.6/Makefile.am	2024-07-04 16:36:55.000000000 +0900
-+++ src/ecm-git-7.0.6/Makefile.am	2025-04-06 16:57:05.510587600 +0900
-@@ -208,3 +208,6 @@ if MAKE_MANPAGE
+--- origsrc/ecm-git-7.0.7/Makefile.am	2026-05-19 08:07:10.000000000 +0000
++++ src/ecm-git-7.0.7/Makefile.am	2026-08-11 10:03:18.557684900 +0000
+@@ -196,3 +196,6 @@ if MAKE_MANPAGE
  ecm.1: $(srcdir)/ecm.xml
  	xsltproc -o ecm.1 $(XSLDIR)/manpages/docbook.xsl $(srcdir)/ecm.xml
  endif
 +
 +pkgconfigdir = $(libdir)/pkgconfig
 +pkgconfig_DATA = $(PACKAGE).pc
---- origsrc/ecm-git-7.0.6/configure.ac	2024-07-04 16:36:55.000000000 +0900
-+++ src/ecm-git-7.0.6/configure.ac	2025-04-06 16:57:05.510587600 +0900
-@@ -716,6 +716,7 @@ endif
+--- origsrc/ecm-git-7.0.7/configure.ac	2026-05-19 08:07:10.000000000 +0000
++++ src/ecm-git-7.0.7/configure.ac	2026-08-11 10:03:18.559700700 +0000
+@@ -727,6 +727,7 @@ endif
  AC_SUBST([COV_FRAG])
  AM_SUBST_NOTMAKE([COV_FRAG])
  
@@ -17,8 +17,8 @@
  AC_OUTPUT
  
  AC_MSG_NOTICE([Configuration:])
---- origsrc/ecm-git-7.0.6/ecm.pc.in	1970-01-01 09:00:00.000000000 +0900
-+++ src/ecm-git-7.0.6/ecm.pc.in	2025-04-06 16:57:05.510587600 +0900
+--- origsrc/ecm-git-7.0.7/ecm.pc.in	1970-01-01 00:00:00.000000000 +0000
++++ src/ecm-git-7.0.7/ecm.pc.in	2026-08-11 10:03:18.560716300 +0000
 @@ -0,0 +1,10 @@
 +prefix=@prefix@
 +exec_prefix=@exec_prefix@


### PR DESCRIPTION
Version `7.0.7`, built and validated by [dorgann](https://github.com/fd00/dorgann).

Run: https://github.com/fd00/dorgann/actions/runs/31480150860

<!-- dorgann-meta: {"artifact_id":"9097139266"} -->

To publish this build to gh-pages:
```
gh workflow run publish.yml -f artifact_id=9097139266 --repo fd00/dorgann
```