### PR TITLE
intx-0.15.0

### DIFF
--- a/intx/README
+++ b/intx/README
@@ -6,32 +6,33 @@ Runtime requirements:
 
 Build requirements:
 (besides corresponding -devel packages)
-  binutils-2.45.1-1
-  cmake-4.1.3-1
-  cygport-0.37.6-1
-  gcc-core-13.4.0-1
-  gcc-g++-13.4.0-1
-  libgtest-devel-1.17.0-1bl1
+  binutils-2.47-1
+  cmake-4.2.1-1
+  cygport-0.37.7-1
+  gcc-core-14.4.0-1
+  gcc-g++-14.4.0-1
+  libbenchmark-devel-1.9.5-1bl2
+  libgtest-devel-1.18.0-1bl1
   ninja-1.13.2-1
 
 Canonical website:
   https://github.com/chfast/intx
 
 Canonical download:
-  https://github.com/chfast/intx/archive/refs/tags/v0.14.0.tar.gz
+  https://github.com/chfast/intx/archive/refs/tags/v0.15.0.tar.gz
 
 -------------------------------------------
 
 Build instructions:
-  1. unpack intx-0.14.0-X-src.tar.xz
+  1. unpack intx-0.15.0-X-src.tar.xz
   2. if you use setup to install this src package,
      it will be unpacked under /usr/src automatically
         % cd /usr/src
-        % cygport ./intx-0.14.0-X.cygport all
+        % cygport ./intx-0.15.0-X.cygport all
 
 This will create:
-  /usr/src/intx-0.14.0-X-src.tar.xz
-  /usr/src/intx-0.14.0-X.tar.xz
+  /usr/src/intx-0.15.0-X-src.tar.xz
+  /usr/src/intx-0.15.0-X.tar.xz
 
 -------------------------------------------
 
@@ -50,6 +51,9 @@ Files included in the binary package:
 ------------------
 
 Port Notes:
+
+----- version 0.15.0-1bl1 -----
+Version bump.
 
 ----- version 0.14.0-1bl1 -----
 Version bump.

--- a/intx/intx-0.15.0-1bl1.cygport
+++ b/intx/intx-0.15.0-1bl1.cygport
@@ -10,6 +10,7 @@ LICENSE_SPDX="SPDX-License-Identifier: Apache-2.0"
 LICENSE_URI="LICENSE"
 
 BUILD_REQUIRES="
+	libbenchmark-devel
 	libgtest-devel
 "
 

--- a/intx/intx-0.15.0-1bl1.src.patch
+++ b/intx/intx-0.15.0-1bl1.src.patch
@@ -1,5 +1,5 @@
---- origsrc/intx-0.14.0/test/benchmarks/CMakeLists.txt	2025-11-14 18:53:48.000000000 +0900
-+++ src/intx-0.14.0/test/benchmarks/CMakeLists.txt	2026-01-12 23:13:14.789285000 +0900
+--- origsrc/intx-0.15.0/test/benchmarks/CMakeLists.txt	2026-01-30 12:26:14.000000000 +0000
++++ src/intx-0.15.0/test/benchmarks/CMakeLists.txt	2026-08-16 02:54:29.401404500 +0000
 @@ -13,6 +13,6 @@ add_executable(intx-bench
      bench_int128.cpp
      benchmarks.cpp


### PR DESCRIPTION
Version `0.15.0`, built and validated by [dorgann](https://github.com/fd00/dorgann).

Run: https://github.com/fd00/dorgann/actions/runs/31870006626

<!-- dorgann-meta: {"artifact_id":"9256975862"} -->

To publish this build to gh-pages:
```
gh workflow run publish.yml -f artifact_id=9256975862 --repo fd00/dorgann
```